### PR TITLE
Fix incorrect type Uint32 defined as uint16

### DIFF
--- a/uint32.go
+++ b/uint32.go
@@ -2,4 +2,4 @@ package ints
 
 // Uint32 is a type that represents an 32-bit unsigned integer.
 // It is an alias for the built-in uint32 type.
-type Uint32 uint16
+type Uint32 uint32


### PR DESCRIPTION
The type alias for Uint32 was incorrectly defined as uint16.
This has been corrected to uint32, which properly represents a 32-bit unsigned integer as intended by the type's name and comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the definition of the 32-bit unsigned integer type to accurately represent a 32-bit value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->