### PR TITLE
Update benchmark tests to use base 62 for Text methods in Int128, Int…

### DIFF
--- a/int128_test.go
+++ b/int128_test.go
@@ -125,7 +125,7 @@ func BenchmarkInt128_Text10(b *testing.B) {
 func BenchmarkInt128_Text62(b *testing.B) {
 	a := Int128{1 << 63, 0}
 	for b.Loop() {
-		runtime.KeepAlive(a.Text(2))
+		runtime.KeepAlive(a.Text(62))
 	}
 }
 

--- a/int256_test.go
+++ b/int256_test.go
@@ -153,7 +153,7 @@ func BenchmarkInt256_Text10(b *testing.B) {
 func BenchmarkInt256_Text62(b *testing.B) {
 	a := Int256{1 << 63, 0, 0, 0}
 	for b.Loop() {
-		runtime.KeepAlive(a.Text(2))
+		runtime.KeepAlive(a.Text(62))
 	}
 }
 

--- a/int512_test.go
+++ b/int512_test.go
@@ -178,7 +178,7 @@ func BenchmarkInt512_Text10(b *testing.B) {
 func BenchmarkInt512_Text62(b *testing.B) {
 	a := Int512{1 << 63, 0, 0, 0, 0, 0, 0, 0}
 	for b.Loop() {
-		runtime.KeepAlive(a.Text(2))
+		runtime.KeepAlive(a.Text(62))
 	}
 }
 


### PR DESCRIPTION
…256, and Int512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated benchmark tests to accurately measure performance for base-62 string conversion, ensuring benchmarks now reflect the intended scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->