### PR TITLE
optimize negate

### DIFF
--- a/int128_test.go
+++ b/int128_test.go
@@ -95,6 +95,9 @@ func FuzzInt128_String(f *testing.F) {
 	f.Add(uint64(0), uint64(0))
 	f.Add(uint64(1), uint64(0))
 	f.Add(uint64(math.MaxUint64), uint64(math.MaxUint64))
+	f.Add(uint64(1<<63), uint64(0))
+	f.Add(uint64(1<<63), uint64(1))
+
 	f.Fuzz(func(t *testing.T, u0, u1 uint64) {
 		a := Int128{u0, u1}
 		got := a.String()

--- a/int256_test.go
+++ b/int256_test.go
@@ -123,6 +123,7 @@ func FuzzInt256_String(f *testing.F) {
 	f.Add(uint64(0), uint64(1), uint64(0), uint64(0))
 	f.Add(uint64(1), uint64(0), uint64(0), uint64(0))
 	f.Add(uint64(math.MaxUint64), uint64(math.MaxUint64), uint64(math.MaxUint64), uint64(math.MaxUint64))
+	f.Add(uint64(1<<63), uint64(0), uint64(0), uint64(0))
 	f.Fuzz(func(t *testing.T, u0, u1, u2, u3 uint64) {
 		a := Int256{u0, u1, u2, u3}
 		got := a.String()

--- a/ints.go
+++ b/ints.go
@@ -102,10 +102,10 @@ func formatBits128(dst []byte, u0, u1 uint64, base int, neg, append_ bool) (d []
 	i := len(a)
 
 	if neg {
-		// u = -u = ^u + 1
-		var carry uint64
-		u1, carry = bits.Add64(^u1, 1, 0)
-		u0, _ = bits.Add64(^u0, 0, carry)
+		// u = -u = 0 - u
+		var borrow uint64
+		u1, borrow = bits.Sub64(0, u1, 0)
+		u0, _ = bits.Add64(0, u0, borrow)
 	}
 
 	// general case
@@ -151,12 +151,12 @@ func formatBits256(dst []byte, u0, u1, u2, u3 uint64, base int, neg, append_ boo
 	i := len(a)
 
 	if neg {
-		// u = -u = ^u + 1
-		var carry uint64
-		u3, carry = bits.Add64(^u3, 1, 0)
-		u2, _ = bits.Add64(^u2, 0, carry)
-		u1, _ = bits.Add64(^u1, 0, carry)
-		u0, _ = bits.Add64(^u0, 0, carry)
+		// u = -u = 0 - u
+		var borrow uint64
+		u3, borrow = bits.Sub64(0, u3, 0)
+		u2, borrow = bits.Sub64(0, u2, borrow)
+		u1, borrow = bits.Sub64(0, u1, borrow)
+		u0, _ = bits.Sub64(0, u0, borrow)
 	}
 
 	// general case
@@ -221,16 +221,16 @@ func formatBits512(dst []byte, u0, u1, u2, u3, u4, u5, u6, u7 uint64, base int, 
 	i := len(a)
 
 	if neg {
-		// u = -u = ^u + 1
-		var carry uint64
-		u7, carry = bits.Add64(^u7, 1, 0)
-		u6, carry = bits.Add64(^u6, 0, carry)
-		u5, carry = bits.Add64(^u5, 0, carry)
-		u4, carry = bits.Add64(^u4, 0, carry)
-		u3, carry = bits.Add64(^u3, 0, carry)
-		u2, carry = bits.Add64(^u2, 0, carry)
-		u1, carry = bits.Add64(^u1, 0, carry)
-		u0, _ = bits.Add64(^u0, 0, carry)
+		// u = -u = 0 - u
+		var borrow uint64
+		u7, borrow = bits.Sub64(0, u7, 0)
+		u6, borrow = bits.Sub64(0, u6, borrow)
+		u5, borrow = bits.Sub64(0, u5, borrow)
+		u4, borrow = bits.Sub64(0, u4, borrow)
+		u3, borrow = bits.Sub64(0, u3, borrow)
+		u2, borrow = bits.Sub64(0, u2, borrow)
+		u1, borrow = bits.Sub64(0, u1, borrow)
+		u0, _ = bits.Sub64(0, u0, borrow)
 	}
 
 	// general case
@@ -345,24 +345,24 @@ func formatBits1024(dst []byte, u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11
 	i := len(a)
 
 	if neg {
-		// u = -u = ^u + 1
-		var carry uint64
-		u15, carry = bits.Add64(^u15, 1, 0)
-		u14, carry = bits.Add64(^u14, 0, carry)
-		u13, carry = bits.Add64(^u13, 0, carry)
-		u12, carry = bits.Add64(^u12, 0, carry)
-		u11, carry = bits.Add64(^u11, 0, carry)
-		u10, carry = bits.Add64(^u10, 0, carry)
-		u9, carry = bits.Add64(^u9, 0, carry)
-		u8, carry = bits.Add64(^u8, 0, carry)
-		u7, carry = bits.Add64(^u7, 0, carry)
-		u6, carry = bits.Add64(^u6, 0, carry)
-		u5, carry = bits.Add64(^u5, 0, carry)
-		u4, carry = bits.Add64(^u4, 0, carry)
-		u3, carry = bits.Add64(^u3, 0, carry)
-		u2, carry = bits.Add64(^u2, 0, carry)
-		u1, carry = bits.Add64(^u1, 0, carry)
-		u0, _ = bits.Add64(^u0, 0, carry)
+		// u = -u = 0 - u
+		var borrow uint64
+		u15, borrow = bits.Sub64(0, u15, 0)
+		u14, borrow = bits.Sub64(0, u14, borrow)
+		u13, borrow = bits.Sub64(0, u13, borrow)
+		u12, borrow = bits.Sub64(0, u12, borrow)
+		u11, borrow = bits.Sub64(0, u11, borrow)
+		u10, borrow = bits.Sub64(0, u10, borrow)
+		u9, borrow = bits.Sub64(0, u9, borrow)
+		u8, borrow = bits.Sub64(0, u8, borrow)
+		u7, borrow = bits.Sub64(0, u7, borrow)
+		u6, borrow = bits.Sub64(0, u6, borrow)
+		u5, borrow = bits.Sub64(0, u5, borrow)
+		u4, borrow = bits.Sub64(0, u4, borrow)
+		u3, borrow = bits.Sub64(0, u3, borrow)
+		u2, borrow = bits.Sub64(0, u2, borrow)
+		u1, borrow = bits.Sub64(0, u1, borrow)
+		u0, _ = bits.Sub64(0, u0, borrow)
 	}
 
 	// general case

--- a/ints.go
+++ b/ints.go
@@ -105,7 +105,7 @@ func formatBits128(dst []byte, u0, u1 uint64, base int, neg, append_ bool) (d []
 		// u = -u = 0 - u
 		var borrow uint64
 		u1, borrow = bits.Sub64(0, u1, 0)
-		u0, _ = bits.Add64(0, u0, borrow)
+		u0, _ = bits.Sub64(0, u0, borrow)
 	}
 
 	// general case


### PR DESCRIPTION
```plain
% benchstat .old.txt .new.txt                                                                                                                            fix-benchmark-of-text
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/ints
cpu: Apple M1 Pro
                   │  .old.txt   │              .new.txt              │
                   │   sec/op    │   sec/op     vs base               │
Int1024_Text2-10     11.57µ ± 0%   11.57µ ± 0%       ~ (p=0.644 n=10)
Int1024_Text10-10    12.18µ ± 0%   12.18µ ± 0%       ~ (p=0.698 n=10)
Int1024_Text62-10    11.57µ ± 0%   11.56µ ± 0%  -0.09% (p=0.011 n=10)
Int1024_String-10    12.38µ ± 1%   12.20µ ± 1%  -1.51% (p=0.001 n=10)
Int128_Text2-10      429.1n ± 2%   422.0n ± 0%  -1.65% (p=0.000 n=10)
Int128_Text10-10     217.8n ± 2%   214.8n ± 0%  -1.38% (p=0.000 n=10)
Int128_Text62-10     121.7n ± 1%   120.4n ± 0%  -1.07% (p=0.000 n=10)
Int128_String-10     220.5n ± 2%   213.7n ± 0%  -3.08% (p=0.000 n=10)
Int256_Text2-10      1.048µ ± 1%   1.031µ ± 0%  -1.58% (p=0.000 n=10)
Int256_Text10-10     700.8n ± 3%   692.2n ± 0%  -1.23% (p=0.000 n=10)
Int256_Text62-10     406.2n ± 2%   401.5n ± 0%  -1.17% (p=0.000 n=10)
Int256_String-10     699.3n ± 1%   691.7n ± 0%  -1.09% (p=0.000 n=10)
Int512_Text2-10      3.124µ ± 3%   3.082µ ± 1%  -1.33% (p=0.002 n=10)
Int512_Text10-10     2.584µ ± 3%   2.547µ ± 1%  -1.45% (p=0.000 n=10)
Int512_Text62-10     1.680µ ± 2%   1.664µ ± 1%  -0.95% (p=0.013 n=10)
Int512_String-10     2.579µ ± 1%   2.542µ ± 0%  -1.45% (p=0.000 n=10)
Uint1024_Text2-10    43.60µ ± 2%   43.26µ ± 0%  -0.78% (p=0.000 n=10)
Uint1024_Text10-10   12.54µ ± 2%   12.36µ ± 0%  -1.43% (p=0.000 n=10)
Uint1024_Text62-10   8.449µ ± 2%   8.299µ ± 0%  -1.78% (p=0.000 n=10)
Uint1024_String-10   12.57µ ± 2%   12.36µ ± 0%  -1.72% (p=0.000 n=10)
Uint128_Text2-10     645.9n ± 3%   643.5n ± 0%  -0.38% (p=0.002 n=10)
Uint128_Text10-10    223.2n ± 3%   218.5n ± 0%  -2.13% (p=0.000 n=10)
Uint128_Text62-10    128.1n ± 4%   125.2n ± 0%  -2.23% (p=0.000 n=10)
Uint128_String-10    218.2n ± 1%   217.6n ± 0%       ~ (p=0.092 n=10)
Uint256_Text2-10     2.061µ ± 0%   2.059µ ± 0%       ~ (p=0.467 n=10)
Uint256_Text10-10    677.3n ± 0%   677.0n ± 0%       ~ (p=0.362 n=10)
Uint256_Text62-10    402.4n ± 0%   402.3n ± 0%       ~ (p=0.253 n=10)
Uint256_String-10    677.2n ± 0%   676.8n ± 0%       ~ (p=0.092 n=10)
Uint512_Text2-10     8.506µ ± 0%   8.504µ ± 0%       ~ (p=0.146 n=10)
Uint512_Text10-10    2.659µ ± 0%   2.685µ ± 1%       ~ (p=0.092 n=10)
Uint512_Text62-10    1.645µ ± 0%   1.664µ ± 3%  +1.19% (p=0.000 n=10)
Uint512_String-10    2.668µ ± 0%   2.702µ ± 1%  +1.27% (p=0.000 n=10)
geomean              1.598µ        1.585µ       -0.83%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of negative multi-word unsigned integers for large number formatting (128-bit, 256-bit, 512-bit, and 1024-bit values). No changes to visible features or exported interfaces.
- **Tests**
  - Expanded fuzz testing with new edge case inputs for 128-bit and 256-bit integer string conversions to enhance reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->