### PR TITLE
Add bitwise operations for unsigned integer types

### DIFF
--- a/int1024.go
+++ b/int1024.go
@@ -81,6 +81,116 @@ func (a Int1024) Mul(b Int1024) Int1024 {
 	return c
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int1024) And(b Int1024) Int1024 {
+	return Int1024{
+		a[0] & b[0],
+		a[1] & b[1],
+		a[2] & b[2],
+		a[3] & b[3],
+		a[4] & b[4],
+		a[5] & b[5],
+		a[6] & b[6],
+		a[7] & b[7],
+		a[8] & b[8],
+		a[9] & b[9],
+		a[10] & b[10],
+		a[11] & b[11],
+		a[12] & b[12],
+		a[13] & b[13],
+		a[14] & b[14],
+		a[15] & b[15],
+	}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int1024) AndNot(b Int1024) Int1024 {
+	return Int1024{
+		a[0] &^ b[0],
+		a[1] &^ b[1],
+		a[2] &^ b[2],
+		a[3] &^ b[3],
+		a[4] &^ b[4],
+		a[5] &^ b[5],
+		a[6] &^ b[6],
+		a[7] &^ b[7],
+		a[8] &^ b[8],
+		a[9] &^ b[9],
+		a[10] &^ b[10],
+		a[11] &^ b[11],
+		a[12] &^ b[12],
+		a[13] &^ b[13],
+		a[14] &^ b[14],
+		a[15] &^ b[15],
+	}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int1024) Or(b Int1024) Int1024 {
+	return Int1024{
+		a[0] | b[0],
+		a[1] | b[1],
+		a[2] | b[2],
+		a[3] | b[3],
+		a[4] | b[4],
+		a[5] | b[5],
+		a[6] | b[6],
+		a[7] | b[7],
+		a[8] | b[8],
+		a[9] | b[9],
+		a[10] | b[10],
+		a[11] | b[11],
+		a[12] | b[12],
+		a[13] | b[13],
+		a[14] | b[14],
+		a[15] | b[15],
+	}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int1024) Xor(b Int1024) Int1024 {
+	return Int1024{
+		a[0] ^ b[0],
+		a[1] ^ b[1],
+		a[2] ^ b[2],
+		a[3] ^ b[3],
+		a[4] ^ b[4],
+		a[5] ^ b[5],
+		a[6] ^ b[6],
+		a[7] ^ b[7],
+		a[8] ^ b[8],
+		a[9] ^ b[9],
+		a[10] ^ b[10],
+		a[11] ^ b[11],
+		a[12] ^ b[12],
+		a[13] ^ b[13],
+		a[14] ^ b[14],
+		a[15] ^ b[15],
+	}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int1024) Not() Int1024 {
+	return Int1024{
+		^a[0],
+		^a[1],
+		^a[2],
+		^a[3],
+		^a[4],
+		^a[5],
+		^a[6],
+		^a[7],
+		^a[8],
+		^a[9],
+		^a[10],
+		^a[11],
+		^a[12],
+		^a[13],
+		^a[14],
+		^a[15],
+	}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int1024_test.go
+++ b/int1024_test.go
@@ -155,6 +155,129 @@ func FuzzInt1024_Mul(f *testing.F) {
 	})
 }
 
+func TestInt1024_And(t *testing.T) {
+	testCases := []struct {
+		x    Int1024
+		y    Int1024
+		want Int1024
+	}{
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt1024_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Int1024
+		y    Int1024
+		want Int1024
+	}{
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt1024_Or(t *testing.T) {
+	testCases := []struct {
+		x    Int1024
+		y    Int1024
+		want Int1024
+	}{
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt1024_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Int1024
+		y    Int1024
+		want Int1024
+	}{
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt1024_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int1024
+		want Int1024
+	}{
+		{
+			Int1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Int1024{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint1024(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt1024_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int1024

--- a/int128.go
+++ b/int128.go
@@ -53,6 +53,31 @@ func (a Int128) Mul(b Int128) Int128 {
 	return c
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int128) And(b Int128) Int128 {
+	return Int128{a[0] & b[0], a[1] & b[1]}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int128) AndNot(b Int128) Int128 {
+	return Int128{a[0] &^ b[0], a[1] &^ b[1]}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int128) Or(b Int128) Int128 {
+	return Int128{a[0] | b[0], a[1] | b[1]}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int128) Xor(b Int128) Int128 {
+	return Int128{a[0] ^ b[0], a[1] ^ b[1]}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int128) Not() Int128 {
+	return Int128{^a[0], ^a[1]}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int128_test.go
+++ b/int128_test.go
@@ -130,6 +130,99 @@ func FuzzInt128_Mul(f *testing.F) {
 	})
 }
 
+func TestInt128_And(t *testing.T) {
+	testCases := []struct {
+		x    Int128
+		y    Int128
+		want Int128
+	}{
+		{Int128{0, 0}, Int128{0, 0}, Int128{0, 0}},
+		{Int128{1, 0}, Int128{1, 0}, Int128{1, 0}},
+		{Int128{1, 0}, Int128{2, 0}, Int128{0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Int128(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt128_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Int128
+		y    Int128
+		want Int128
+	}{
+		{Int128{0, 0}, Int128{0, 0}, Int128{0, 0}},
+		{Int128{1, 0}, Int128{1, 0}, Int128{0, 0}},
+		{Int128{1, 0}, Int128{2, 0}, Int128{1, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Int128(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt128_Or(t *testing.T) {
+	testCases := []struct {
+		x    Int128
+		y    Int128
+		want Int128
+	}{
+		{Int128{0, 0}, Int128{0, 0}, Int128{0, 0}},
+		{Int128{1, 0}, Int128{1, 0}, Int128{1, 0}},
+		{Int128{1, 0}, Int128{2, 0}, Int128{3, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Int128(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt128_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Int128
+		y    Int128
+		want Int128
+	}{
+		{Int128{0, 0}, Int128{0, 0}, Int128{0, 0}},
+		{Int128{1, 0}, Int128{1, 0}, Int128{0, 0}},
+		{Int128{1, 0}, Int128{2, 0}, Int128{3, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Int128(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt128_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int128
+		want Int128
+	}{
+		{Int128{0, 0}, Int128{math.MaxUint64, math.MaxUint64}},
+		{Int128{1, 0}, Int128{math.MaxUint64 - 1, math.MaxUint64}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int128(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt128_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int128

--- a/int16.go
+++ b/int16.go
@@ -35,6 +35,31 @@ func (a Int16) Mul(b Int16) Int16 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int16) And(b Int16) Int16 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int16) AndNot(b Int16) Int16 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int16) Or(b Int16) Int16 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int16) Xor(b Int16) Int16 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int16) Not() Int16 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int16_test.go
+++ b/int16_test.go
@@ -56,6 +56,106 @@ func FuzzInt16_Mul(f *testing.F) {
 	})
 }
 
+func TestInt16_And(t *testing.T) {
+	testCases := []struct {
+		x    Int16
+		y    Int16
+		want Int16
+	}{
+		{0, 0, 0},
+		{1, 1, 1},
+		{-1, -1, -1},
+		{127, 255, 127},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Int16(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt16_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Int16
+		y    Int16
+		want Int16
+	}{
+		{0, 0, 0},
+		{1, 1, 0},
+		{-1, -1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Int16(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt16_Or(t *testing.T) {
+	testCases := []struct {
+		x    Int16
+		y    Int16
+		want Int16
+	}{
+		{0, 0, 0},
+		{1, 1, 1},
+		{-1, -1, -1},
+		{127, 255, 255},
+		{-128, -255, -127},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Int16(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt16_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Int16
+		y    Int16
+		want Int16
+	}{
+		{0, 0, 0},
+		{1, 1, 0},
+		{-1, -1, 0},
+		{127, 255, 128},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Int16(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt16_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int16
+		want Int16
+	}{
+		{0, -1},
+		{1, -2},
+		{-1, 0},
+		{127, -128},
+		{-128, 127},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int16(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt16_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int16

--- a/int256.go
+++ b/int256.go
@@ -57,6 +57,56 @@ func (a Int256) Mul(b Int256) Int256 {
 	return c
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int256) And(b Int256) Int256 {
+	return Int256{
+		a[0] & b[0],
+		a[1] & b[1],
+		a[2] & b[2],
+		a[3] & b[3],
+	}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int256) AndNot(b Int256) Int256 {
+	return Int256{
+		a[0] &^ b[0],
+		a[1] &^ b[1],
+		a[2] &^ b[2],
+		a[3] &^ b[3],
+	}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int256) Or(b Int256) Int256 {
+	return Int256{
+		a[0] | b[0],
+		a[1] | b[1],
+		a[2] | b[2],
+		a[3] | b[3],
+	}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int256) Xor(b Int256) Int256 {
+	return Int256{
+		a[0] ^ b[0],
+		a[1] ^ b[1],
+		a[2] ^ b[2],
+		a[3] ^ b[3],
+	}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int256) Not() Int256 {
+	return Int256{
+		^a[0],
+		^a[1],
+		^a[2],
+		^a[3],
+	}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int256_test.go
+++ b/int256_test.go
@@ -130,6 +130,100 @@ func FuzzInt256_Mul(f *testing.F) {
 	})
 }
 
+func TestInt256_And(t *testing.T) {
+	testCases := []struct {
+		x    Int256
+		y    Int256
+		want Int256
+	}{
+		{Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}},
+		{Int256{1, 1, 1, 1}, Int256{1, 1, 1, 1}, Int256{1, 1, 1, 1}},
+		{Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Int256(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt256_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Int256
+		y    Int256
+		want Int256
+	}{
+		{Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}},
+		{Int256{1, 1, 1, 1}, Int256{1, 1, 1, 1}, Int256{0, 0, 0, 0}},
+		{Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{0, 0, 0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Int256(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt256_Or(t *testing.T) {
+	testCases := []struct {
+		x    Int256
+		y    Int256
+		want Int256
+	}{
+		{Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}},
+		{Int256{1, 1, 1, 1}, Int256{1, 1, 1, 1}, Int256{1, 1, 1, 1}},
+		{Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Int256(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt256_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Int256
+		y    Int256
+		want Int256
+	}{
+		{Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}, Int256{0, 0, 0, 0}},
+		{Int256{1, 1, 1, 1}, Int256{1, 1, 1, 1}, Int256{0, 0, 0, 0}},
+		{Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{0, 0, 0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Int256(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt256_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int256
+		want Int256
+	}{
+		{Int256{0, 0, 0, 0}, Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}},
+		{Int256{1, 1, 1, 1}, Int256{math.MaxUint64 - 1, math.MaxUint64 - 1, math.MaxUint64 - 1, math.MaxUint64 - 1}},
+		{Int256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}, Int256{0, 0, 0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int256(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt256_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int256

--- a/int32.go
+++ b/int32.go
@@ -35,6 +35,31 @@ func (a Int32) Mul(b Int32) Int32 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int32) And(b Int32) Int32 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int32) AndNot(b Int32) Int32 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int32) Or(b Int32) Int32 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int32) Xor(b Int32) Int32 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int32) Not() Int32 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int32_test.go
+++ b/int32_test.go
@@ -55,6 +55,99 @@ func FuzzInt32_Mul(f *testing.F) {
 	})
 }
 
+func TestInt32_And(t *testing.T) {
+	testCases := []struct {
+		x    Int32
+		y    Int32
+		want Int32
+	}{
+		{0, 0, 0},
+		{1, 0, 0},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Int32(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt32_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Int32
+		y    Int32
+		want Int32
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Int32(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt32_Or(t *testing.T) {
+	testCases := []struct {
+		x    Int32
+		y    Int32
+		want Int32
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Int32(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt32_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Int32
+		y    Int32
+		want Int32
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Int32(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt32_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int32
+		want Int32
+	}{
+		{0, -1},
+		{1, -2},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int32(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt32_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int32

--- a/int512.go
+++ b/int512.go
@@ -65,6 +65,76 @@ func (a Int512) Mul(b Int512) Int512 {
 	return c
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int512) And(b Int512) Int512 {
+	return Int512{
+		a[0] & b[0],
+		a[1] & b[1],
+		a[2] & b[2],
+		a[3] & b[3],
+		a[4] & b[4],
+		a[5] & b[5],
+		a[6] & b[6],
+		a[7] & b[7],
+	}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int512) AndNot(b Int512) Int512 {
+	return Int512{
+		a[0] &^ b[0],
+		a[1] &^ b[1],
+		a[2] &^ b[2],
+		a[3] &^ b[3],
+		a[4] &^ b[4],
+		a[5] &^ b[5],
+		a[6] &^ b[6],
+		a[7] &^ b[7],
+	}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int512) Or(b Int512) Int512 {
+	return Int512{
+		a[0] | b[0],
+		a[1] | b[1],
+		a[2] | b[2],
+		a[3] | b[3],
+		a[4] | b[4],
+		a[5] | b[5],
+		a[6] | b[6],
+		a[7] | b[7],
+	}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int512) Xor(b Int512) Int512 {
+	return Int512{
+		a[0] ^ b[0],
+		a[1] ^ b[1],
+		a[2] ^ b[2],
+		a[3] ^ b[3],
+		a[4] ^ b[4],
+		a[5] ^ b[5],
+		a[6] ^ b[6],
+		a[7] ^ b[7],
+	}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int512) Not() Int512 {
+	return Int512{
+		^a[0],
+		^a[1],
+		^a[2],
+		^a[3],
+		^a[4],
+		^a[5],
+		^a[6],
+		^a[7],
+	}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int512_test.go
+++ b/int512_test.go
@@ -144,6 +144,97 @@ func FuzzInt512_Mul(f *testing.F) {
 	})
 }
 
+func TestInt512_And(t *testing.T) {
+	testCases := []struct {
+		a    Int512
+		b    Int512
+		want Int512
+	}{
+		{Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}},
+		{Int512{1, 1, 1, 1, 1, 1, 1, 1}, Int512{2, 2, 2, 2, 2, 2, 2, 2}, Int512{0, 0, 0, 0, 0, 0, 0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.And(tc.b)
+		if got != tc.want {
+			t.Errorf("Int512(%d).And(%d) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestInt512_AndNot(t *testing.T) {
+	testCases := []struct {
+		a    Int512
+		b    Int512
+		want Int512
+	}{
+		{Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}},
+		{Int512{1, 1, 1, 1, 1, 1, 1, 1}, Int512{2, 2, 2, 2, 2, 2, 2, 2}, Int512{1, 1, 1, 1, 1, 1, 1, 1}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.AndNot(tc.b)
+		if got != tc.want {
+			t.Errorf("Int512(%d).AndNot(%d) = %d", tc.a, tc.b, got)
+		}
+	}
+}
+
+func TestInt512_Or(t *testing.T) {
+	testCases := []struct {
+		a    Int512
+		b    Int512
+		want Int512
+	}{
+		{Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}},
+		{Int512{1, 1, 1, 1, 1, 1, 1, 1}, Int512{2, 2, 2, 2, 2, 2, 2, 2}, Int512{3, 3, 3, 3, 3, 3, 3, 3}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.Or(tc.b)
+		if got != tc.want {
+			t.Errorf("Int512(%d).Or(%d) = %d", tc.a, tc.b, got)
+		}
+	}
+}
+
+func TestInt512_Xor(t *testing.T) {
+	testCases := []struct {
+		a    Int512
+		b    Int512
+		want Int512
+	}{
+		{Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}, Int512{0, 0, 0, 0, 0, 0, 0, 0}},
+		{Int512{1, 1, 1, 1, 1, 1, 1, 1}, Int512{2, 2, 2, 2, 2, 2, 2, 2}, Int512{3, 3, 3, 3, 3, 3, 3, 3}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.Xor(tc.b)
+		if got != tc.want {
+			t.Errorf("Int512(%d).Xor(%d) = %d", tc.a, tc.b, got)
+		}
+	}
+}
+
+func TestInt512_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int512
+		want Int512
+	}{
+		{
+			Int512{0, 0, 0, 0, 0, 0, 0, 0},
+			Int512{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int512(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt512_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int512

--- a/int64.go
+++ b/int64.go
@@ -35,6 +35,31 @@ func (a Int64) Mul(b Int64) Int64 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int64) And(b Int64) Int64 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int64) AndNot(b Int64) Int64 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int64) Or(b Int64) Int64 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int64) Xor(b Int64) Int64 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int64) Not() Int64 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int64_test.go
+++ b/int64_test.go
@@ -55,6 +55,105 @@ func FuzzInt64_Mul(f *testing.F) {
 	})
 }
 
+func TestInt64_And(t *testing.T) {
+	testCases := []struct {
+		x    Int64
+		y    Int64
+		want Int64
+	}{
+		{0, 0, 0},
+		{1, 0, 0},
+		{1, 1, 1},
+		{math.MaxInt64, math.MaxInt64, math.MaxInt64},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Int64(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt64_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Int64
+		y    Int64
+		want Int64
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+		{math.MaxInt64, math.MaxInt64, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Int64(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt64_Or(t *testing.T) {
+	testCases := []struct {
+		x    Int64
+		y    Int64
+		want Int64
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 1},
+		{math.MaxInt64, math.MaxInt64, math.MaxInt64},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Int64(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt64_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Int64
+		y    Int64
+		want Int64
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+		{math.MaxInt64, math.MaxInt64, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Int64(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestInt64_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int64
+		want Int64
+	}{
+		{0, -1},
+		{1, -2},
+		{-1, 0},
+		{math.MaxInt64, -math.MaxInt64 - 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int64(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt64_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int64

--- a/int8.go
+++ b/int8.go
@@ -35,6 +35,31 @@ func (a Int8) Mul(b Int8) Int8 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Int8) And(b Int8) Int8 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Int8) AndNot(b Int8) Int8 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Int8) Or(b Int8) Int8 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Int8) Xor(b Int8) Int8 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Int8) Not() Int8 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/int8_test.go
+++ b/int8_test.go
@@ -56,6 +56,104 @@ func FuzzInt8_Mul(f *testing.F) {
 	})
 }
 
+func TestInt8_And(t *testing.T) {
+	testCases := []struct {
+		a, b Int8
+		want Int8
+	}{
+		{0, 0, 0},
+		{1, 0, 0},
+		{1, 1, 1},
+		{1, -1, 1},
+		{-1, -1, -1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.And(tc.b)
+		if got != tc.want {
+			t.Errorf("Int8(%d).And(%d) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestInt8_AndNot(t *testing.T) {
+	testCases := []struct {
+		a, b Int8
+		want Int8
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+		{1, -1, 0},
+		{-1, -1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.AndNot(tc.b)
+		if got != tc.want {
+			t.Errorf("Int8(%d).AndNot(%d) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestInt8_Or(t *testing.T) {
+	testCases := []struct {
+		a, b Int8
+		want Int8
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 1},
+		{1, -1, -1},
+		{-1, -1, -1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.Or(tc.b)
+		if got != tc.want {
+			t.Errorf("Int8(%d).Or(%d) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestInt8_Xor(t *testing.T) {
+	testCases := []struct {
+		a, b Int8
+		want Int8
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+		{1, -1, -2},
+		{-1, -1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.a.Xor(tc.b)
+		if got != tc.want {
+			t.Errorf("Int8(%d).Xor(%d) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestInt8_Not(t *testing.T) {
+	testCases := []struct {
+		x    Int8
+		want Int8
+	}{
+		{0, -1},
+		{1, -2},
+		{-1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Int8(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestInt8_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Int8

--- a/uint1024.go
+++ b/uint1024.go
@@ -800,6 +800,116 @@ func (a Uint1024) Mul(b Uint1024) Uint1024 {
 	return Uint1024{u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15}
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint1024) And(b Uint1024) Uint1024 {
+	return Uint1024{
+		a[0] & b[0],
+		a[1] & b[1],
+		a[2] & b[2],
+		a[3] & b[3],
+		a[4] & b[4],
+		a[5] & b[5],
+		a[6] & b[6],
+		a[7] & b[7],
+		a[8] & b[8],
+		a[9] & b[9],
+		a[10] & b[10],
+		a[11] & b[11],
+		a[12] & b[12],
+		a[13] & b[13],
+		a[14] & b[14],
+		a[15] & b[15],
+	}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint1024) AndNot(b Uint1024) Uint1024 {
+	return Uint1024{
+		a[0] &^ b[0],
+		a[1] &^ b[1],
+		a[2] &^ b[2],
+		a[3] &^ b[3],
+		a[4] &^ b[4],
+		a[5] &^ b[5],
+		a[6] &^ b[6],
+		a[7] &^ b[7],
+		a[8] &^ b[8],
+		a[9] &^ b[9],
+		a[10] &^ b[10],
+		a[11] &^ b[11],
+		a[12] &^ b[12],
+		a[13] &^ b[13],
+		a[14] &^ b[14],
+		a[15] &^ b[15],
+	}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint1024) Or(b Uint1024) Uint1024 {
+	return Uint1024{
+		a[0] | b[0],
+		a[1] | b[1],
+		a[2] | b[2],
+		a[3] | b[3],
+		a[4] | b[4],
+		a[5] | b[5],
+		a[6] | b[6],
+		a[7] | b[7],
+		a[8] | b[8],
+		a[9] | b[9],
+		a[10] | b[10],
+		a[11] | b[11],
+		a[12] | b[12],
+		a[13] | b[13],
+		a[14] | b[14],
+		a[15] | b[15],
+	}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint1024) Xor(b Uint1024) Uint1024 {
+	return Uint1024{
+		a[0] ^ b[0],
+		a[1] ^ b[1],
+		a[2] ^ b[2],
+		a[3] ^ b[3],
+		a[4] ^ b[4],
+		a[5] ^ b[5],
+		a[6] ^ b[6],
+		a[7] ^ b[7],
+		a[8] ^ b[8],
+		a[9] ^ b[9],
+		a[10] ^ b[10],
+		a[11] ^ b[11],
+		a[12] ^ b[12],
+		a[13] ^ b[13],
+		a[14] ^ b[14],
+		a[15] ^ b[15],
+	}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint1024) Not() Uint1024 {
+	return Uint1024{
+		^a[0],
+		^a[1],
+		^a[2],
+		^a[3],
+		^a[4],
+		^a[5],
+		^a[6],
+		^a[7],
+		^a[8],
+		^a[9],
+		^a[10],
+		^a[11],
+		^a[12],
+		^a[13],
+		^a[14],
+		^a[15],
+	}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint1024_test.go
+++ b/uint1024_test.go
@@ -123,6 +123,119 @@ func FuzzUint1024_Mul(f *testing.F) {
 	})
 }
 
+func TestUint1024_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint1024
+		y    Uint1024
+		want Uint1024
+	}{
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		},
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%s).And(%s) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint1024_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint1024
+		y    Uint1024
+		want Uint1024
+	}{
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%s).AndNot(%s) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint1024_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint1024
+		y    Uint1024
+		want Uint1024
+	}{
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%s).Or(%s) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint1024_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint1024
+		y    Uint1024
+		want Uint1024
+	}{
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint1024(%s).Xor(%s) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint1024_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint1024
+		want Uint1024
+	}{
+		{
+			Uint1024{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Uint1024{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint1024(%s).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint1024_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint1024

--- a/uint128.go
+++ b/uint128.go
@@ -43,6 +43,31 @@ func (a Uint128) Mul(b Uint128) Uint128 {
 	return Uint128{h + h1 + h2, l}
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint128) And(b Uint128) Uint128 {
+	return Uint128{a[0] & b[0], a[1] & b[1]}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint128) AndNot(b Uint128) Uint128 {
+	return Uint128{a[0] &^ b[0], a[1] &^ b[1]}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint128) Or(b Uint128) Uint128 {
+	return Uint128{a[0] | b[0], a[1] | b[1]}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint128) Xor(b Uint128) Uint128 {
+	return Uint128{a[0] ^ b[0], a[1] ^ b[1]}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint128) Not() Uint128 {
+	return Uint128{^a[0], ^a[1]}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -109,6 +109,95 @@ func FuzzUint128_Mul(f *testing.F) {
 	})
 }
 
+func TestUint128_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint128
+		y    Uint128
+		want Uint128
+	}{
+		{Uint128{0, 0}, Uint128{0, 0}, Uint128{0, 0}},
+		{Uint128{1, 1}, Uint128{1, 1}, Uint128{1, 1}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint128(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint128_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint128
+		y    Uint128
+		want Uint128
+	}{
+		{Uint128{0, 0}, Uint128{0, 0}, Uint128{0, 0}},
+		{Uint128{1, 1}, Uint128{1, 1}, Uint128{0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint128(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint128_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint128
+		y    Uint128
+		want Uint128
+	}{
+		{Uint128{0, 0}, Uint128{0, 0}, Uint128{0, 0}},
+		{Uint128{1, 1}, Uint128{1, 1}, Uint128{1, 1}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint128(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint128_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint128
+		y    Uint128
+		want Uint128
+	}{
+		{Uint128{0, 0}, Uint128{0, 0}, Uint128{0, 0}},
+		{Uint128{1, 1}, Uint128{1, 1}, Uint128{0, 0}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint128(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint128_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint128
+		want Uint128
+	}{
+		{Uint128{0, 0}, Uint128{math.MaxUint64, math.MaxUint64}},
+		{Uint128{1, 1}, Uint128{math.MaxUint64 - 1, math.MaxUint64 - 1}},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint128(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint128_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint128

--- a/uint16.go
+++ b/uint16.go
@@ -33,6 +33,31 @@ func (a Uint16) Mul(b Uint16) Uint16 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint16) And(b Uint16) Uint16 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint16) AndNot(b Uint16) Uint16 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint16) Or(b Uint16) Uint16 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint16) Xor(b Uint16) Uint16 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint16) Not() Uint16 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -53,6 +53,98 @@ func FuzzUint16_Mul(f *testing.F) {
 	})
 }
 
+func TestUint16_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint16
+		y    Uint16
+		want Uint16
+	}{
+		{0, 0, 0},
+		{1, 0, 0},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint16(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint16_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint16
+		y    Uint16
+		want Uint16
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint16(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint16_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint16
+		y    Uint16
+		want Uint16
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint16(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint16_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint16
+		y    Uint16
+		want Uint16
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint16(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint16_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint16
+		want Uint16
+	}{
+		{0, math.MaxUint16},
+		{1, math.MaxUint16 - 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint16(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
 func TestUint16_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint16

--- a/uint256.go
+++ b/uint256.go
@@ -105,6 +105,56 @@ func (a Uint256) Mul(b Uint256) Uint256 {
 	return Uint256{u0, u1, u2, u3}
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint256) And(b Uint256) Uint256 {
+	return Uint256{
+		a[0] & b[0],
+		a[1] & b[1],
+		a[2] & b[2],
+		a[3] & b[3],
+	}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint256) AndNot(b Uint256) Uint256 {
+	return Uint256{
+		a[0] &^ b[0],
+		a[1] &^ b[1],
+		a[2] &^ b[2],
+		a[3] &^ b[3],
+	}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint256) Or(b Uint256) Uint256 {
+	return Uint256{
+		a[0] | b[0],
+		a[1] | b[1],
+		a[2] | b[2],
+		a[3] | b[3],
+	}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint256) Xor(b Uint256) Uint256 {
+	return Uint256{
+		a[0] ^ b[0],
+		a[1] ^ b[1],
+		a[2] ^ b[2],
+		a[3] ^ b[3],
+	}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint256) Not() Uint256 {
+	return Uint256{
+		^a[0],
+		^a[1],
+		^a[2],
+		^a[3],
+	}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -105,6 +105,138 @@ func FuzzUint256_Mul(f *testing.F) {
 	})
 }
 
+func TestUint256_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint256
+		y    Uint256
+		want Uint256
+	}{
+		{
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+		},
+		{
+			Uint256{1, 1, 1, 1},
+			Uint256{1, 1, 1, 1},
+			Uint256{1, 1, 1, 1},
+		},
+		{
+			Uint256{1, 1, 1, 1},
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint256(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint256_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint256
+		y    Uint256
+		want Uint256
+	}{
+		{
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+		},
+		{
+			Uint256{1, 1, 1, 1},
+			Uint256{1, 1, 1, 1},
+			Uint256{0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint256(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint256_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint256
+		y    Uint256
+		want Uint256
+	}{
+		{
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+		},
+		{
+			Uint256{1, 1, 1, 1},
+			Uint256{1, 1, 1, 1},
+			Uint256{1, 1, 1, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint256(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint256_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint256
+		y    Uint256
+		want Uint256
+	}{
+		{
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+			Uint256{0, 0, 0, 0},
+		},
+		{
+			Uint256{1, 1, 1, 1},
+			Uint256{1, 1, 1, 1},
+			Uint256{0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint256(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint256_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint256
+		want Uint256
+	}{
+		{
+			Uint256{0, 0, 0, 0},
+			Uint256{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64},
+		},
+		{
+			Uint256{1, 1, 1, 1},
+			Uint256{math.MaxUint64 - 1, math.MaxUint64 - 1, math.MaxUint64 - 1, math.MaxUint64 - 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint256(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint256_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint256

--- a/uint32.go
+++ b/uint32.go
@@ -33,6 +33,31 @@ func (a Uint32) Mul(b Uint32) Uint32 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint32) And(b Uint32) Uint32 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint32) AndNot(b Uint32) Uint32 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint32) Or(b Uint32) Uint32 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint32) Xor(b Uint32) Uint32 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint32) Not() Uint32 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -52,6 +52,95 @@ func FuzzUint32_Mul(f *testing.F) {
 	})
 }
 
+func TestUint32_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint32
+		y    Uint32
+		want Uint32
+	}{
+		{0, 0, 0},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint32(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint32_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint32
+		y    Uint32
+		want Uint32
+	}{
+		{0, 0, 0},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint32(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint32_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint32
+		y    Uint32
+		want Uint32
+	}{
+		{0, 0, 0},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint32(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint32_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint32
+		y    Uint32
+		want Uint32
+	}{
+		{0, 0, 0},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint32(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint32_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint32
+		want Uint32
+	}{
+		{0, math.MaxUint32},
+		{1, math.MaxUint32 - 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint32(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint32_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint32

--- a/uint512.go
+++ b/uint512.go
@@ -267,6 +267,76 @@ func (a Uint512) Mul(b Uint512) Uint512 {
 	return Uint512{u0, u1, u2, u3, u4, u5, u6, u7}
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint512) And(b Uint512) Uint512 {
+	return Uint512{
+		a[0] & b[0],
+		a[1] & b[1],
+		a[2] & b[2],
+		a[3] & b[3],
+		a[4] & b[4],
+		a[5] & b[5],
+		a[6] & b[6],
+		a[7] & b[7],
+	}
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint512) AndNot(b Uint512) Uint512 {
+	return Uint512{
+		a[0] &^ b[0],
+		a[1] &^ b[1],
+		a[2] &^ b[2],
+		a[3] &^ b[3],
+		a[4] &^ b[4],
+		a[5] &^ b[5],
+		a[6] &^ b[6],
+		a[7] &^ b[7],
+	}
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint512) Or(b Uint512) Uint512 {
+	return Uint512{
+		a[0] | b[0],
+		a[1] | b[1],
+		a[2] | b[2],
+		a[3] | b[3],
+		a[4] | b[4],
+		a[5] | b[5],
+		a[6] | b[6],
+		a[7] | b[7],
+	}
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint512) Xor(b Uint512) Uint512 {
+	return Uint512{
+		a[0] ^ b[0],
+		a[1] ^ b[1],
+		a[2] ^ b[2],
+		a[3] ^ b[3],
+		a[4] ^ b[4],
+		a[5] ^ b[5],
+		a[6] ^ b[6],
+		a[7] ^ b[7],
+	}
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint512) Not() Uint512 {
+	return Uint512{
+		^a[0],
+		^a[1],
+		^a[2],
+		^a[3],
+		^a[4],
+		^a[5],
+		^a[6],
+		^a[7],
+	}
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint512_test.go
+++ b/uint512_test.go
@@ -117,6 +117,129 @@ func FuzzUint512_Mul(f *testing.F) {
 	})
 }
 
+func TestUint512_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint512
+		y    Uint512
+		want Uint512
+	}{
+		{
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint512(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint512_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint512
+		y    Uint512
+		want Uint512
+	}{
+		{
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint512(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint512_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint512
+		y    Uint512
+		want Uint512
+	}{
+		{
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint512(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint512_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint512
+		y    Uint512
+		want Uint512
+	}{
+		{
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{1, 1, 1, 1, 1, 1, 1, 1},
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint512(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint512_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint512
+		want Uint512
+	}{
+		{
+			Uint512{0, 0, 0, 0, 0, 0, 0, 0},
+			Uint512{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint512(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint512_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint512

--- a/uint64.go
+++ b/uint64.go
@@ -33,14 +33,29 @@ func (a Uint64) Mul(b Uint64) Uint64 {
 	return a * b
 }
 
-// Sign returns the sign of a.
-// It returns 1 if a > 0, and 0 if a == 0.
-// It does not return -1 because Uint64 is unsigned.
-func (a Uint64) Sign() int {
-	if a == 0 {
-		return 0
-	}
-	return 1
+// And returns the bitwise AND of a and b.
+func (a Uint64) And(b Uint64) Uint64 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint64) AndNot(b Uint64) Uint64 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint64) Or(b Uint64) Uint64 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint64) Xor(b Uint64) Uint64 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint64) Not() Uint64 {
+	return ^a
 }
 
 // Lsh returns the logical left shift a<<i.
@@ -55,6 +70,16 @@ func (a Uint64) Lsh(i uint) Uint64 {
 // This function's execution time does not depend on the inputs.
 func (a Uint64) Rsh(i uint) Uint64 {
 	return a >> i
+}
+
+// Sign returns the sign of a.
+// It returns 1 if a > 0, and 0 if a == 0.
+// It does not return -1 because Uint64 is unsigned.
+func (a Uint64) Sign() int {
+	if a == 0 {
+		return 0
+	}
+	return 1
 }
 
 // Neg returns the negation of a.

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -52,6 +52,99 @@ func FuzzUint64_Mul(f *testing.F) {
 	})
 }
 
+func TestUint64_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint64
+		y    Uint64
+		want Uint64
+	}{
+		{0, 0, 0},
+		{1, 0, 0},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint64(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint64_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint64
+		y    Uint64
+		want Uint64
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint64(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint64_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint64
+		y    Uint64
+		want Uint64
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint64(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint64_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint64
+		y    Uint64
+		want Uint64
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint64(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint64_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint64
+		want Uint64
+	}{
+		{0, math.MaxUint64},
+		{1, math.MaxUint64 - 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint64(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint64_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint64

--- a/uint8.go
+++ b/uint8.go
@@ -33,6 +33,31 @@ func (a Uint8) Mul(b Uint8) Uint8 {
 	return a * b
 }
 
+// And returns the bitwise AND of a and b.
+func (a Uint8) And(b Uint8) Uint8 {
+	return a & b
+}
+
+// AndNot returns the bitwise AND NOT of a and b.
+func (a Uint8) AndNot(b Uint8) Uint8 {
+	return a &^ b
+}
+
+// Or returns the bitwise OR of a and b.
+func (a Uint8) Or(b Uint8) Uint8 {
+	return a | b
+}
+
+// Xor returns the bitwise XOR of a and b.
+func (a Uint8) Xor(b Uint8) Uint8 {
+	return a ^ b
+}
+
+// Not returns the bitwise NOT of a.
+func (a Uint8) Not() Uint8 {
+	return ^a
+}
+
 // Lsh returns the logical left shift a<<i.
 //
 // This function's execution time does not depend on the inputs.

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -53,6 +53,100 @@ func FuzzUint8_Mul(f *testing.F) {
 	})
 }
 
+func TestUint8_And(t *testing.T) {
+	testCases := []struct {
+		x    Uint8
+		y    Uint8
+		want Uint8
+	}{
+		{0, 0, 0},
+		{1, 0, 0},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.And(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint8(%d).And(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint8_AndNot(t *testing.T) {
+	testCases := []struct {
+		x    Uint8
+		y    Uint8
+		want Uint8
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.AndNot(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint8(%d).AndNot(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint8_Or(t *testing.T) {
+	testCases := []struct {
+		x    Uint8
+		y    Uint8
+		want Uint8
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Or(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint8(%d).Or(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint8_Xor(t *testing.T) {
+	testCases := []struct {
+		x    Uint8
+		y    Uint8
+		want Uint8
+	}{
+		{0, 0, 0},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Xor(tc.y)
+		if got != tc.want {
+			t.Errorf("Uint8(%d).Xor(%d) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestUint8_Not(t *testing.T) {
+	testCases := []struct {
+		x    Uint8
+		want Uint8
+	}{
+		{0, 0xff},
+		{1, 0xfe},
+		{0xff, 0},
+	}
+
+	for _, tc := range testCases {
+		got := tc.x.Not()
+		if got != tc.want {
+			t.Errorf("Uint8(%d).Not() = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+}
+
 func TestUint8_Lsh(t *testing.T) {
 	testCases := []struct {
 		x    Uint8


### PR DESCRIPTION
- Implemented bitwise AND, AND NOT, OR, XOR, and NOT operations for Uint8, Uint16, Uint32, Uint64, Uint128, Uint256, Uint512.
- Added corresponding unit tests for each operation to ensure correctness across all unsigned integer types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bitwise operations (AND, AND NOT, OR, XOR, NOT) for all signed and unsigned integer types, including 8, 16, 32, 64, 128, 256, 512, and 1024-bit variants.

- **Tests**
  - Introduced comprehensive unit tests to verify correctness of all new bitwise operations across supported integer types.

- **Refactor**
  - Relocated an existing method for improved organization (no change in behavior).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->