### PR TITLE
Add benchmark tests for addition of Uint128, Uint256, Uint512, and Ui…

### DIFF
--- a/uint1024_test.go
+++ b/uint1024_test.go
@@ -53,6 +53,27 @@ func FuzzUint1024_Add(f *testing.F) {
 	})
 }
 
+func BenchmarkUint1024_Add(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint1024{0x80000000_00000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	y := Uint1024{0x7f000000_00000000, M, M, M, M, M, M, M, M, M, M, M, M, M, M, M}
+
+	b.Run("Uint1024", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Add(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint1024ToBigInt(x)
+		yy := uint1024ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Add(xx, yy)
+		}
+	})
+}
+
 func FuzzUint1024_Sub(f *testing.F) {
 	f.Add(
 		// 0

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -47,6 +47,26 @@ func FuzzUint128_Add(f *testing.F) {
 	})
 }
 
+func BenchmarkUint128_Add(b *testing.B) {
+	x := Uint128{0x80000000_00000000, 0}
+	y := Uint128{0x7f000000_00000000, 0xffffffff_ffffffff}
+
+	b.Run("Uint128", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Add(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint128ToBigInt(x)
+		yy := uint128ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Add(xx, yy)
+		}
+	})
+}
+
 func FuzzUint128_Sub(f *testing.F) {
 	f.Add(
 		uint64(0), uint64(0),

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -47,6 +47,26 @@ func FuzzUint256_Add(f *testing.F) {
 	})
 }
 
+func BenchmarkUint256_Add(b *testing.B) {
+	x := Uint256{0x80000000_00000000, 0, 0, 0}
+	y := Uint256{0x7f000000_00000000, 0xffffffff_ffffffff, 0xffffffff_ffffffff, 0xffffffff_ffffffff}
+
+	b.Run("Uint256", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Add(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint256ToBigInt(x)
+		yy := uint256ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Add(xx, yy)
+		}
+	})
+}
+
 func FuzzUint256_Sub(f *testing.F) {
 	f.Add(
 		uint64(0), uint64(0), uint64(0), uint64(0), // 0

--- a/uint512_test.go
+++ b/uint512_test.go
@@ -49,6 +49,27 @@ func FuzzUint512_Add(f *testing.F) {
 	})
 }
 
+func BenchmarkUint512_Add(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint512{0x80000000_00000000, 0, 0, 0, 0, 0, 0, 0}
+	y := Uint512{0x7f000000_00000000, M, M, M, M, M, M, M}
+
+	b.Run("Uint512", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Add(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint512ToBigInt(x)
+		yy := uint512ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Add(xx, yy)
+		}
+	})
+}
+
 func FuzzUint512_Sub(f *testing.F) {
 	f.Add(
 		// 0


### PR DESCRIPTION
…nt1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added benchmark tests to measure and compare the performance of addition operations for custom Uint128, Uint256, Uint512, and Uint1024 types versus Go's standard big.Int type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->