### PR TITLE
Add benchmark tests for multiplication of Uint128, Uint256, Uint512, …

### DIFF
--- a/uint1024_test.go
+++ b/uint1024_test.go
@@ -144,6 +144,27 @@ func FuzzUint1024_Mul(f *testing.F) {
 	})
 }
 
+func BenchmarkUint1024_Mul(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint1024{0, 0, 0, 0, 0, 0, 0, 0, M, M, M, M, M, M, M, M}
+	y := Uint1024{0, 0, 0, 0, 0, 0, 0, 0, M, M, M, M, M, M, M, M}
+
+	b.Run("Uint1024", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Mul(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint1024ToBigInt(x)
+		yy := uint1024ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Mul(xx, yy)
+		}
+	})
+}
+
 func FuzzUint1024_DivMod(f *testing.F) {
 	// f.Add(
 	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -129,6 +129,26 @@ func FuzzUint128_Mul(f *testing.F) {
 	})
 }
 
+func BenchmarkUint128_Mul(b *testing.B) {
+	x := Uint128{0, 0xffffffff_ffffffff}
+	y := Uint128{0, 0xffffffff_ffffffff}
+
+	b.Run("Uint128", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Mul(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint128ToBigInt(x)
+		yy := uint128ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Mul(xx, yy)
+		}
+	})
+}
+
 func FuzzUint128_DivMod(f *testing.F) {
 	f.Add(
 		uint64(0), uint64(127),

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -125,6 +125,27 @@ func FuzzUint256_Mul(f *testing.F) {
 	})
 }
 
+func BenchmarkUint256_Mul(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint256{0, 0, M, M}
+	y := Uint256{0, 0, M, M}
+
+	b.Run("Uint256", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Mul(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint256ToBigInt(x)
+		yy := uint256ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Mul(xx, yy)
+		}
+	})
+}
+
 func FuzzUint256_DivMod(f *testing.F) {
 	f.Add(
 		uint64(0), uint64(0), uint64(0), uint64(127),

--- a/uint512_test.go
+++ b/uint512_test.go
@@ -138,6 +138,27 @@ func FuzzUint512_Mul(f *testing.F) {
 	})
 }
 
+func BenchmarkUint512_Mul(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint512{0, 0, 0, 0, M, M, M, M}
+	y := Uint512{0, 0, 0, 0, M, M, M, M}
+
+	b.Run("Uint512", func(b *testing.B) {
+		for b.Loop() {
+			runtime.KeepAlive(x.Mul(y))
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint512ToBigInt(x)
+		yy := uint512ToBigInt(y)
+		zz := new(big.Int)
+		for b.Loop() {
+			zz.Mul(xx, yy)
+		}
+	})
+}
+
 func FuzzUint512_DivMod(f *testing.F) {
 	f.Add(
 		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(127),


### PR DESCRIPTION
…and Uint1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new benchmarks to measure and compare multiplication performance for custom Uint128, Uint256, Uint512, and Uint1024 types against Go's standard big.Int type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->