### PR TITLE
Add benchmark tests for DivMod on Uint128, Uint256, and Uint512

### DIFF
--- a/uint1024_test.go
+++ b/uint1024_test.go
@@ -219,6 +219,28 @@ func FuzzUint1024_DivMod(f *testing.F) {
 	})
 }
 
+func BenchmarkUint1024_DivMod(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint1024{M, M, M, M, M, M, M, M, M, M, M, M, M, M, M, M}
+	y := Uint1024{1, M, M, M, M, M, M, M, M, M, M, M, M, M, M, M}
+
+	b.Run("Uint1024", func(b *testing.B) {
+		for b.Loop() {
+			x.DivMod(y)
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint1024ToBigInt(x)
+		yy := uint1024ToBigInt(y)
+		q := new(big.Int)
+		r := new(big.Int)
+		for b.Loop() {
+			q.DivMod(xx, yy, r)
+		}
+	})
+}
+
 func TestUint1024_And(t *testing.T) {
 	testCases := []struct {
 		x    Uint1024

--- a/uint1024_test.go
+++ b/uint1024_test.go
@@ -166,26 +166,26 @@ func BenchmarkUint1024_Mul(b *testing.B) {
 }
 
 func FuzzUint1024_DivMod(f *testing.F) {
-	// f.Add(
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(127),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(10),
-	// )
+	f.Add(
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(127),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(10),
+	)
 
-	// f.Add(
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(10),
-	// )
+	f.Add(
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(10),
+	)
 
-	// f.Add(
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(2),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
-	// 	uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
-	// )
+	f.Add(
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(2),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(1),
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
+	)
 
 	f.Fuzz(func(t *testing.T, u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 uint64) {
 		a := Uint1024{u0, u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15}

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -190,6 +190,28 @@ func FuzzUint128_DivMod(f *testing.F) {
 	})
 }
 
+func BenchmarkUint128_DivMod(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint128{M, M}
+	y := Uint128{1, M}
+
+	b.Run("Uint128", func(b *testing.B) {
+		for b.Loop() {
+			x.DivMod(y)
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint128ToBigInt(x)
+		yy := uint128ToBigInt(y)
+		q := new(big.Int)
+		r := new(big.Int)
+		for b.Loop() {
+			q, r = q.DivMod(xx, yy, r)
+		}
+	})
+}
+
 func TestUint128_And(t *testing.T) {
 	testCases := []struct {
 		x    Uint128

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -191,6 +191,28 @@ func FuzzUint256_DivMod(f *testing.F) {
 	})
 }
 
+func BenchmarkUint256_DivMod(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint256{M, M, M, M}
+	y := Uint256{1, M, M, M}
+
+	b.Run("Uint256", func(b *testing.B) {
+		for b.Loop() {
+			x.DivMod(y)
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint256ToBigInt(x)
+		yy := uint256ToBigInt(y)
+		q := new(big.Int)
+		r := new(big.Int)
+		for b.Loop() {
+			q.DivMod(xx, yy, r)
+		}
+	})
+}
+
 func TestUint256_And(t *testing.T) {
 	testCases := []struct {
 		x    Uint256

--- a/uint512_test.go
+++ b/uint512_test.go
@@ -204,6 +204,28 @@ func FuzzUint512_DivMod(f *testing.F) {
 	})
 }
 
+func BenchmarkUint512_DivMod(b *testing.B) {
+	const M = 0xffffffff_ffffffff
+	x := Uint512{M, M, M, M, M, M, M, M}
+	y := Uint512{1, M, M, M, M, M, M, M}
+
+	b.Run("Uint512", func(b *testing.B) {
+		for b.Loop() {
+			x.DivMod(y)
+		}
+	})
+
+	b.Run("BigInt", func(b *testing.B) {
+		xx := uint512ToBigInt(x)
+		yy := uint512ToBigInt(y)
+		q := new(big.Int)
+		r := new(big.Int)
+		for b.Loop() {
+			q.DivMod(xx, yy, r)
+		}
+	})
+}
+
 func TestUint512_And(t *testing.T) {
 	testCases := []struct {
 		x    Uint512


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added benchmark tests to measure the performance of division and modulo operations for Uint128, Uint256, Uint512, and Uint1024 types, including comparisons with Go's big.Int implementation.

- **Tests**
  - Enabled additional input cases for fuzz testing division and modulo operations on Uint1024 values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->