### PR TITLE
Fix div128 function to use Uint128 for accurate calculations in division

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -187,7 +187,7 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 	q1 := un64.Div(yn1)
 	rhat := un64.Sub(q1.Mul(yn1))
 
-	for q1.Cmp(two64) >= 0 || q1.Mul(yn0).Cmp(two64.Mul(rhat).Add(un1)) > 0 {
+	for q1.Cmp(two64) >= 0 || q1.Mul(yn0).Cmp(Uint128{rhat[1], 0}.Add(un1)) > 0 {
 		q1 = q1.Sub(Uint128{0, 1})
 		rhat = rhat.Add(yn1)
 		if rhat.Cmp(two64) >= 0 {
@@ -195,11 +195,11 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 		}
 	}
 
-	un21 := un64.Mul(two64).Add(un1).Sub(q1.Mul(y))
+	un21 := Uint128{un64[1], 0}.Add(un1).Sub(q1.Mul(y))
 	q0 := un21.Div(yn1)
 	rhat = un21.Sub(q0.Mul(yn1))
 
-	for q0.Cmp(two64) >= 0 || q0.Mul(yn0).Cmp(two64.Mul(rhat).Add(un0)) > 0 {
+	for q0.Cmp(two64) >= 0 || q0.Mul(yn0).Cmp(Uint128{rhat[1], 0}.Add(un0)) > 0 {
 		q0 = q0.Sub(Uint128{0, 1})
 		rhat = rhat.Add(yn1)
 		if rhat.Cmp(two64) >= 0 {
@@ -207,7 +207,7 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 		}
 	}
 
-	return q1.Mul(two64).Add(q0), un21.Mul(two64).Add(un0).Sub(q0.Mul(y)).Rsh(s)
+	return Uint128{q1[1], 0}.Add(q0), Uint128{rhat[1], 0}.Add(un0).Sub(q0.Mul(y)).Rsh(s)
 }
 
 // Quo returns the quotient a/b for b != 0.


### PR DESCRIPTION
```
% benchstat .old.txt .new.txt                                                                                                                                                      main
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/ints
cpu: Apple M1 Pro
                         │  .old.txt   │              .new.txt              │
                         │   sec/op    │   sec/op     vs base               │
Uint256_DivMod/Uint256-8   159.6n ± 1%   143.7n ± 3%  -9.96% (p=0.000 n=10)
Uint256_DivMod/BigInt-8    75.09n ± 1%   75.27n ± 3%       ~ (p=0.239 n=10)
geomean                    109.5n        104.0n       -5.00%

                         │   .old.txt   │              .new.txt               │
                         │     B/op     │    B/op     vs base                 │
Uint256_DivMod/Uint256-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Uint256_DivMod/BigInt-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │   .old.txt   │              .new.txt               │
                         │  allocs/op   │ allocs/op   vs base                 │
Uint256_DivMod/Uint256-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Uint256_DivMod/BigInt-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of 128-bit division calculations, resulting in more reliable arithmetic operations for large numbers. No changes to user-facing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->