### PR TITLE
use logical shift instead of Mul

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -287,7 +287,7 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 	q1 := un64.Div(yn1)
 	rhat := un64.Sub(q1.Mul(yn1))
 
-	for q1.Cmp(two64) >= 0 || q1.Mul(yn0).Cmp(two64.Mul(rhat).Add(un1)) > 0 {
+	for q1.Cmp(two64) >= 0 || q1.Mul(yn0).Cmp(Uint128{rhat[1], 0}.Add(un1)) > 0 {
 		q1 = q1.Sub(Uint128{0, 1})
 		rhat = rhat.Add(yn1)
 		if rhat.Cmp(two64) >= 0 {
@@ -295,11 +295,11 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 		}
 	}
 
-	un21 := un64.Mul(two64).Add(un1).Sub(q1.Mul(y))
+	un21 := Uint128{un64[1], 0}.Add(un1).Sub(q1.Mul(y))
 	q0 := un21.Div(yn1)
 	rhat = un21.Sub(q0.Mul(yn1))
 
-	for q0.Cmp(two64) >= 0 || q0.Mul(yn0).Cmp(two64.Mul(rhat).Add(un0)) > 0 {
+	for q0.Cmp(two64) >= 0 || q0.Mul(yn0).Cmp(Uint128{rhat[1], 0}.Add(un0)) > 0 {
 		q0 = q0.Sub(Uint128{0, 1})
 		rhat = rhat.Add(yn1)
 		if rhat.Cmp(two64) >= 0 {
@@ -307,7 +307,7 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 		}
 	}
 
-	return q1.Mul(two64).Add(q0), un21.Mul(two64).Add(un0).Sub(q0.Mul(y)).Rsh(s)
+	return Uint128{q1[1], 0}.Add(q0), Uint128{un21[1], 0}.Add(un0).Sub(q0.Mul(y)).Rsh(s)
 }
 
 // Quo returns the quotient a/b for b != 0.


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/ints
cpu: Apple M1 Pro
                          │  .old.txt   │              .new.txt              │
                          │   sec/op    │   sec/op     vs base               │
Uint256_DivMod/Uint256-10   157.7n ± 2%   142.4n ± 1%  -9.73% (p=0.000 n=10)
Uint256_DivMod/BigInt-10    74.98n ± 1%   74.47n ± 0%  -0.68% (p=0.002 n=10)
geomean                     108.8n        103.0n       -5.31%

                          │   .old.txt   │              .new.txt               │
                          │     B/op     │    B/op     vs base                 │
Uint256_DivMod/Uint256-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Uint256_DivMod/BigInt-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │   .old.txt   │              .new.txt               │
                          │  allocs/op   │ allocs/op   vs base                 │
Uint256_DivMod/Uint256-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Uint256_DivMod/BigInt-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Before:

<img width="857" alt="image" src="https://github.com/user-attachments/assets/80a741a2-0ab7-47ef-9657-683a5b26b278" />


After:

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/925b0a45-2476-4e14-99b0-235bd9efecfa" />
