### PR TITLE
use logical or instead of Add

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -282,12 +282,10 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 	yn0 := Uint128{0, y[1]}
 	un64 := hi.Lsh(s).Or(lo.Rsh(128 - s))
 	un10 := lo.Lsh(s)
-	un1 := Uint128{0, un10[0]}
-	un0 := Uint128{0, un10[1]}
 	q1 := un64.Div(yn1)
 	rhat := un64.Sub(q1.Mul(yn1))
 
-	for q1.Cmp(two64) >= 0 || q1.Mul(yn0).Cmp(Uint128{rhat[1], 0}.Add(un1)) > 0 {
+	for q1.Cmp(two64) >= 0 || q1.Mul(yn0).Cmp(Uint128{rhat[1], un10[0]}) > 0 {
 		q1 = q1.Sub(Uint128{0, 1})
 		rhat = rhat.Add(yn1)
 		if rhat.Cmp(two64) >= 0 {
@@ -295,11 +293,11 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 		}
 	}
 
-	un21 := Uint128{un64[1], 0}.Add(un1).Sub(q1.Mul(y))
+	un21 := Uint128{un64[1], un10[0]}.Sub(q1.Mul(y))
 	q0 := un21.Div(yn1)
 	rhat = un21.Sub(q0.Mul(yn1))
 
-	for q0.Cmp(two64) >= 0 || q0.Mul(yn0).Cmp(Uint128{rhat[1], 0}.Add(un0)) > 0 {
+	for q0.Cmp(two64) >= 0 || q0.Mul(yn0).Cmp(Uint128{rhat[1], un10[1]}) > 0 {
 		q0 = q0.Sub(Uint128{0, 1})
 		rhat = rhat.Add(yn1)
 		if rhat.Cmp(two64) >= 0 {
@@ -307,7 +305,7 @@ func div128(hi, lo, y Uint128) (quo, rem Uint128) {
 		}
 	}
 
-	return Uint128{q1[1], 0}.Add(q0), Uint128{un21[1], 0}.Add(un0).Sub(q0.Mul(y)).Rsh(s)
+	return Uint128{q1[1], 0}.Add(q0), Uint128{un21[1], un10[1]}.Sub(q0.Mul(y)).Rsh(s)
 }
 
 // Quo returns the quotient a/b for b != 0.


### PR DESCRIPTION
```plain
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/ints
cpu: Apple M1 Pro
                          │  .old.txt   │              .new.txt              │
                          │   sec/op    │   sec/op     vs base               │
Uint256_DivMod/Uint256-10   142.3n ± 0%   139.3n ± 0%  -2.11% (p=0.000 n=10)
Uint256_DivMod/BigInt-10    75.05n ± 1%   74.48n ± 0%  -0.77% (p=0.024 n=10)
geomean                     103.3n        101.9n       -1.44%

                          │   .old.txt   │              .new.txt               │
                          │     B/op     │    B/op     vs base                 │
Uint256_DivMod/Uint256-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Uint256_DivMod/BigInt-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │   .old.txt   │              .new.txt               │
                          │  allocs/op   │ allocs/op   vs base                 │
Uint256_DivMod/Uint256-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Uint256_DivMod/BigInt-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal calculations for division operations, improving code efficiency without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->