### PR TITLE
add Go 1.26 and 1.25 to the test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ jobs:
     strategy:
       matrix:
         go-version:
+          - "1.26"
+          - "1.25"
           - "1.24"
     permissions:
       contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to include Go versions 1.26 and 1.25 alongside the existing 1.24 release for expanded version coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->